### PR TITLE
AD-221891: Fix SearchIndexUpdateTrigger document id error

### DIFF
--- a/NCS.DSS.ChangeFeedListener/Model/CustomerSearch.cs
+++ b/NCS.DSS.ChangeFeedListener/Model/CustomerSearch.cs
@@ -4,7 +4,7 @@ namespace NCS.DSS.ChangeFeedListener.Model
 {
     public class CustomerSearch
     {
-        public Guid? id { get; set; }
+        public Guid? CustomerId { get; set; }
 
         public DateTime? DateOfRegistration { get; set; }
 

--- a/NCS.DSS.ChangeFeedListener/Model/CustomerSearch.cs
+++ b/NCS.DSS.ChangeFeedListener/Model/CustomerSearch.cs
@@ -4,6 +4,7 @@ namespace NCS.DSS.ChangeFeedListener.Model
 {
     public class CustomerSearch
     {
+        [Newtonsoft.Json.JsonProperty(PropertyName = "id")]
         public Guid? CustomerId { get; set; }
 
         public DateTime? DateOfRegistration { get; set; }

--- a/NCS.DSS.ChangeFeedListener/SearchIndexUpdateTrigger/SearchIndexUpdateTrigger.cs
+++ b/NCS.DSS.ChangeFeedListener/SearchIndexUpdateTrigger/SearchIndexUpdateTrigger.cs
@@ -63,6 +63,7 @@ namespace NCS.DSS.ChangeFeedListener.SearchIndexUpdateTrigger
                 catch (RequestFailedException e)
                 {
                     _logger.LogError(e, "Failed to update Customer Docs");
+                    throw;
                 }
                 try
                 {
@@ -77,6 +78,7 @@ namespace NCS.DSS.ChangeFeedListener.SearchIndexUpdateTrigger
                 catch (RequestFailedException e)
                 {
                     _logger.LogError(e, "Failed to update Customer Search Docs");
+                    throw;
                 }
             }
             else


### PR DESCRIPTION
Error message: "The request is invalid. Details: The property 'id' does not exist on type 'search.documentFields' or is not present in the API version '2024-07-01'. Make sure to only use property names that are defined by the type."